### PR TITLE
6 library show page

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,2 +1,0 @@
-class BooksController < ApplicationController
-end

--- a/app/controllers/libraries/books_controller.rb
+++ b/app/controllers/libraries/books_controller.rb
@@ -1,0 +1,12 @@
+class Libraries::BooksController < ApplicationController
+
+  def show
+    
+  end
+  def new
+    @library = Library.find(params[:library_id])
+  end
+
+  def create
+  end
+end

--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -2,4 +2,8 @@ class LibrariesController < ApplicationController
   def index
     @libraries = Library.all
   end
+
+  def show
+    @library = Library.find(params[:id])
+  end
 end

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -5,4 +5,8 @@ class Library < ApplicationRecord
   def full_address
     "#{street}, #{city}, #{state} #{zip}"
   end
+
+  def book_count
+    books.count
+  end
 end

--- a/app/views/libraries/books/new.html.erb
+++ b/app/views/libraries/books/new.html.erb
@@ -1,0 +1,8 @@
+<%= turbo_frame_tag "isbn" do %>
+  <h3>Add a book to this library</h3>
+  <%= form_with url: library_books_path(@library), local: :true do |f| %>
+    <%= f.text_field :isbn, placeholder: 'Enter ISBN' %>
+    <%= f.submit 'Add Book' %>
+  <% end %>
+  <%= button_to 'Cancel', @library, method: :get %>
+<% end %>

--- a/app/views/libraries/show.html.erb
+++ b/app/views/libraries/show.html.erb
@@ -1,4 +1,18 @@
 <h1><%= @library.name %></h1>
 <h2><%= @library.full_address %></h2>
 
-<%  %>
+<%= button_to 'Return to Libraries', libraries_path, method: :get %>
+<br>
+<%= turbo_frame_tag "isbn" do %>
+  <%= button_to 'Add a Book', new_library_book_path(@library), method: :get %>
+<% end %>
+
+<section class="library-books">
+  <h2>Books in this Library</h2>
+
+  <% @library.books.each do |book| %>
+    <div id="book_<%=book.id%>">
+    <%= link_to (image_tag book.book_img), library_book_path(@library, book) %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/libraries/show.html.erb
+++ b/app/views/libraries/show.html.erb
@@ -1,0 +1,4 @@
+<h1><%= @library.name %></h1>
+<h2><%= @library.full_address %></h2>
+
+<%  %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   root "welcome#index"
-  resources :library_books
-  resources :books
-  resources :libraries
+  resources :libraries do
+    resources :books, only: [:new, :create, :show], controller: "libraries/books"
+  end
 
   # Defines the root path route ("/")
   # root "articles#index"

--- a/db/migrate/20230912215449_remove_book_count_from_libraries.rb
+++ b/db/migrate/20230912215449_remove_book_count_from_libraries.rb
@@ -1,0 +1,5 @@
+class RemoveBookCountFromLibraries < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :libraries, :book_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_30_222204) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_12_215449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,7 +33,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_30_222204) do
     t.string "zip"
     t.float "lat"
     t.float "lon"
-    t.integer "book_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+FactoryBot.create(:library, books_count: 5)
+FactoryBot.create(:library, books_count: 5)

--- a/spec/factories/library.rb
+++ b/spec/factories/library.rb
@@ -8,9 +8,17 @@ FactoryBot.define do
     lat { Faker::Address.latitude }
     lon { Faker::Address.longitude }
     
-    trait :with_5_books do
-      FactoryBot.create_list(:book, 5)
-      library_books { FactoryBot.create_list(:library_book, 5) }
+    # Define a transient attribute for the number of books
+    transient do
+      books_count { 0 }
+    end
+
+    # Create books association if books_count is greater than 0
+    after(:create) do |library, evaluator|
+      if evaluator.books_count > 0
+        create_list(:book, evaluator.books_count)
+        create_list(:library_book, evaluator.books_count, library: library)
+      end
     end
   end
 end

--- a/spec/factories/library.rb
+++ b/spec/factories/library.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     zip { Faker::Address.zip_code }
     lat { Faker::Address.latitude }
     lon { Faker::Address.longitude }
-    book_count { Faker::Number.number(digits: 2) }
+    
+    trait :with_5_books do
+      FactoryBot.create_list(:book, 5)
+      library_books { FactoryBot.create_list(:library_book, 5) }
+    end
   end
 end

--- a/spec/features/libraries/index_spec.rb
+++ b/spec/features/libraries/index_spec.rb
@@ -37,5 +37,11 @@ RSpec.describe 'library index' do
       expect(page).to have_link(Library.second.name)
       expect(page).to have_link(Library.last.name)
     end
+
+    it 'When I click on a library name link, I am taken to that libraries show page' do
+      click_link(Library.first.name)
+
+      expect(current_path).to eq(library_path(Library.first))
+    end
   end
 end

--- a/spec/features/libraries/show_spec.rb
+++ b/spec/features/libraries/show_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Library Show Page' do
+  describe 'As a visitor, when I visit a library show page' do
+    before (:each) do
+      VCR.use_cassette('returns_the_number_of_books_at_the_library') do
+        @library = FactoryBot.create(:library, books_count: 5)
+        visit library_path(@library)    
+      end
+    end
+
+      it 'I see the BookHaven name and it is a link to the root_path' do
+        expect(page).to have_link("BookHaven")
+        
+        click_link("BookHaven")
+        
+        expect(current_path).to eq(root_path)
+      end
+
+      it 'I see the name and address of the library' do
+        expect(page).to have_content(@library.name)
+        expect(page).to have_content(@library.full_address)
+      end
+
+      it 'I see a button to Add a book to this library' do
+        expect(page).to have_button("Add a Book")
+
+        
+      end
+  end
+end

--- a/spec/features/libraries/show_spec.rb
+++ b/spec/features/libraries/show_spec.rb
@@ -9,23 +9,59 @@ RSpec.describe 'Library Show Page' do
       end
     end
 
-      it 'I see the BookHaven name and it is a link to the root_path' do
-        expect(page).to have_link("BookHaven")
-        
-        click_link("BookHaven")
-        
-        expect(current_path).to eq(root_path)
-      end
+    it 'I see the BookHaven name and it is a link to the root_path' do
+      expect(page).to have_link("BookHaven")
+      
+      click_link("BookHaven")
+      
+      expect(current_path).to eq(root_path)
+    end
 
-      it 'I see the name and address of the library' do
-        expect(page).to have_content(@library.name)
-        expect(page).to have_content(@library.full_address)
-      end
+    it 'I see the name and address of the library' do
+      expect(page).to have_content(@library.name)
+      expect(page).to have_content(@library.full_address)
+    end
 
-      it 'I see a button to Add a book to this library' do
-        expect(page).to have_button("Add a Book")
+    it 'I see a button Return to Libraries that takes me to the library index page' do
+      expect(page).to have_button("Return to Libraries")
+      
+      click_button("Return to Libraries")
 
-        
+      expect(current_path).to eq(libraries_path)
+    end
+
+    it 'I see a button to Add a book to this library' do
+      expect(page).to have_button("Add a Book")
+    end
+
+    it 'When I click the Add a Book button a form appears to add a books ISBN' do
+      click_button("Add a Book")
+      
+      expect(page).to have_field(:isbn)
+      expect(page).to have_button("Add Book")
+      expect(page).to have_button("Cancel")
+      expect(page).to_not have_button("Add a Book")
+
+      click_button("Cancel")
+
+      expect(page).to_not have_field(:isbn)
+      expect(page).to_not have_button("Add Book")
+      expect(page).to have_button("Add a Book")
+    end
+
+    it 'I see a list of all the books images at this library and each image is a link' do
+      @library.books.each do |book|
+        within("#book_#{book.id}") do
+          expect(page).to have_css("img[src*='#{book.book_img}']")
+          expect(page).to have_link('', href: library_book_path(@library, book))
+        end
       end
+    end
+
+    it 'When I click on a book image, I am taken to that books show page' do
+      click_link('', href: library_book_path(@library, @library.books.first))
+
+      expect(current_path).to eq(library_book_path(@library, @library.books.first))
+    end
   end
 end

--- a/spec/models/library_spec.rb
+++ b/spec/models/library_spec.rb
@@ -17,7 +17,14 @@ RSpec.describe Library, type: :model do
         
         expect(library.full_address).to eq('10 W Colfax Ave, Denver, CO 80202')
       end
-  
+    end
+
+    describe '#book_count' do
+      it 'returns the number of books at the library', :vcr do
+        library = FactoryBot.create(:library, :with_5_books)
+        
+        expect(library.book_count).to eq(5)
+      end
     end
   end
 end

--- a/spec/models/library_spec.rb
+++ b/spec/models/library_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Library, type: :model do
 
     describe '#book_count' do
       it 'returns the number of books at the library', :vcr do
-        library = FactoryBot.create(:library, :with_5_books)
-        
+        library = FactoryBot.create(:library, books_count: 5)
+
         expect(library.book_count).to eq(5)
       end
     end


### PR DESCRIPTION
This PR completes the library show page ticket. 
Turbo frames was used to render the add a book form to the library show page.  The form is rendered from library/:id/books/new route in the Libraries::BooksController#new
No logic or Service/facade/poros have been written for adding a book to a library. 
Books show page has been created but is empty.  The reason for the library book show action being in the Libraries::BooksController is so the route utilizes the library and book id. 

A few changes were made outside of the library show page ticket:
- Removed the book_count attribute from the library table
    - If new books were added to a library then an update to the library record would be needed 
    - book_count is now a model method in the library model so no updates to existing views where .book_count is called and no updates to the library record will be needed.
- Removed library_books and books resources from the routes.  Can add them if/when needed.
    - Nested books routes under libraries in the routes
- Updated the library factory so now we can create a library with any number of books automatically associated with that library.  ``` FactoryBot.create(:library, books_count: 5) ```
- Added 2 libraries with 5 books each to the seeds file. 